### PR TITLE
Fix validator's subscribed status 

### DIFF
--- a/src/components/views/UserInfo.tsx
+++ b/src/components/views/UserInfo.tsx
@@ -58,7 +58,7 @@ export function UserInfo() {
         address: validatorKey as `0x${string}`,
         pending: weiToEth(pendingRewardsWei || 0),
         accumulated: weiToEth(accumulatedRewardsWei || 0),
-        subscribed: status === 'active',
+        subscribed: ['active', 'yellowcard', 'redcard'].includes(status),
         validatorId: validatorIndex,
         validatorKey: validatorKey as `0x${string}`,
         warning: setWarning(status),


### PR DESCRIPTION
a subscribed validator can be in active, recard or yellowcard status, not only "active"