### PR TITLE
Add date column on latest blocks table

### DIFF
--- a/src/components/tables/LatestBlocksTable/LatestBlockTable.stories.ts
+++ b/src/components/tables/LatestBlocksTable/LatestBlockTable.stories.ts
@@ -5,6 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 const data: Block[] = [
   {
     slot: 1,
+    date: "",
     proposer: {
       withdrawalAddress: '0x00005ea00ac477b1030ce78506496e8c2de24bf5',
       validatorKey:
@@ -17,6 +18,7 @@ const data: Block[] = [
   },
   {
     slot: 2,
+    date: "",
     proposer: {
       withdrawalAddress: '0x00005ea00ac477b1030ce78506496e8c2de24bf5',
       validatorKey:
@@ -29,6 +31,7 @@ const data: Block[] = [
   },
   {
     slot: 3,
+    date: "",
     proposer: {
       withdrawalAddress: '0x00005ea00ac477b1030ce78506496e8c2de24bf5',
       validatorKey:
@@ -41,6 +44,7 @@ const data: Block[] = [
   },
   {
     slot: 4,
+    date: "",
     proposer: {
       withdrawalAddress: '0x00005ea00ac477b1030ce78506496e8c2de24bf5',
       validatorKey:
@@ -53,6 +57,7 @@ const data: Block[] = [
   },
   {
     slot: 5,
+    date: "",
     proposer: {
       withdrawalAddress: '0x00005ea00ac477b1030ce78506496e8c2de24bf5',
       validatorKey:
@@ -65,6 +70,7 @@ const data: Block[] = [
   },
   {
     slot: 6,
+    date: "",
     proposer: {
       withdrawalAddress: '0x00005ea00ac477b1030ce78506496e8c2de24bf5',
       validatorKey:
@@ -77,6 +83,7 @@ const data: Block[] = [
   },
   {
     slot: 7,
+    date: "",
     proposer: {
       withdrawalAddress: '0x00005ea00ac477b1030ce78506496e8c2de24bf5',
       validatorKey:
@@ -89,6 +96,7 @@ const data: Block[] = [
   },
   {
     slot: 8,
+    date: "",
     proposer: {
       withdrawalAddress: '0x00005ea00ac477b1030ce78506496e8c2de24bf5',
       validatorKey:
@@ -101,6 +109,7 @@ const data: Block[] = [
   },
   {
     slot: 9,
+    date: "",
     proposer: {
       withdrawalAddress: '0x00005ea00ac477b1030ce78506496e8c2de24bf5',
       validatorKey:
@@ -113,6 +122,7 @@ const data: Block[] = [
   },
   {
     slot: 10,
+    date: "",
     proposer: {
       withdrawalAddress: '0x00005ea00ac477b1030ce78506496e8c2de24bf5',
       validatorKey:
@@ -125,6 +135,7 @@ const data: Block[] = [
   },
   {
     slot: 11,
+    date: "",
     proposer: {
       withdrawalAddress: '0x00005ea00ac477b1030ce78506496e8c2de24bf5',
       validatorKey:
@@ -137,6 +148,7 @@ const data: Block[] = [
   },
   {
     slot: 12,
+    date: "",
     proposer: {
       withdrawalAddress: '0x00005ea00ac477b1030ce78506496e8c2de24bf5',
       validatorKey:

--- a/src/components/tables/LatestBlocksTable/config.ts
+++ b/src/components/tables/LatestBlocksTable/config.ts
@@ -2,6 +2,7 @@ export const PAGE_SIZE = 10
 
 export const headerTooltip = {
   slot: 'Slot of the block',
+  date: 'Date of the block',
   proposer: 'Key of the validator',
   rewardType: 'Type of the reward (vanila or mev)',
   reward: 'Reward of the block',

--- a/src/components/tables/LatestBlocksTable/index.tsx
+++ b/src/components/tables/LatestBlocksTable/index.tsx
@@ -40,16 +40,21 @@ const getRelativeTimeFromSlot = (slot: number) => {
     const dayStr = days === 1 ? 'day' : 'days';
     const hourStr = remainingHours === 1 ? 'hour' : 'hours';
     return `${days} ${dayStr} ${remainingHours} ${hourStr} ago`;
-  } else if (hours > 0) {
+  }
+  
+  if (hours > 0) {
     const hourStr = hours === 1 ? 'hour' : 'hours';
     return `${hours} ${hourStr} ago`;
-  } else if (minutes > 0) {
+  }
+  
+  if (minutes > 0) {
     const minuteStr = minutes === 1 ? 'minute' : 'minutes';
     return `${minutes} ${minuteStr} ago`;
-  } else {
-    return `${seconds} seconds ago`;
   }
+  
+  return `${seconds} seconds ago`;
 };
+
 
 const getAbsoluteTimeFromSlot = (slot: number) => {
   const genesisUnixTime = 1606824023; // Unix time of the genesis block

--- a/src/components/tables/LatestBlocksTable/index.tsx
+++ b/src/components/tables/LatestBlocksTable/index.tsx
@@ -18,6 +18,53 @@ import type { Block } from '../types'
 
 const columnHelper = createColumnHelper<Block>()
 
+const getRelativeTimeFromSlot = (slot: number) => {
+  const genesisUnixTime = 1606824023; // Unix time of the genesis block
+  const slotDurationSeconds = 12; // Duration for each slot in seconds
+
+  // Calculate the timestamp for the given slot
+  const slotTimestamp = genesisUnixTime + slot * slotDurationSeconds;
+
+  // Calculate the difference between current time and the slot time
+  const currentTime = Math.floor(Date.now() / 1000); // Current time in seconds
+  const timeDifference = currentTime - slotTimestamp;
+
+  // Convert time difference to human-readable format
+  const minutes = Math.floor(timeDifference / 60);
+  const seconds = timeDifference % 60;
+  const hours = Math.floor(timeDifference / 3600);
+  const days = Math.floor(timeDifference / 86400);
+
+  if (days > 0) {
+    const remainingHours = Math.floor((timeDifference % 86400) / 3600);
+    const dayStr = days === 1 ? 'day' : 'days';
+    const hourStr = remainingHours === 1 ? 'hour' : 'hours';
+    return `${days} ${dayStr} ${remainingHours} ${hourStr} ago`;
+  } else if (hours > 0) {
+    const hourStr = hours === 1 ? 'hour' : 'hours';
+    return `${hours} ${hourStr} ago`;
+  } else if (minutes > 0) {
+    const minuteStr = minutes === 1 ? 'minute' : 'minutes';
+    return `${minutes} ${minuteStr} ago`;
+  } else {
+    return `${seconds} seconds ago`;
+  }
+};
+
+const getAbsoluteTimeFromSlot = (slot: number) => {
+  const genesisUnixTime = 1606824023; // Unix time of the genesis block
+  const slotDurationSeconds = 12; // Duration for each slot in seconds
+
+  // Calculate the timestamp for the given slot
+  const slotTimestamp = genesisUnixTime + slot * slotDurationSeconds;
+
+  // Create a Date object using the calculated timestamp
+  const absoluteDate = new Date(slotTimestamp * 1000);
+
+  // Return the formatted absolute date in local time
+  return absoluteDate.toLocaleString();
+};
+
 const getColumns = (blackExplorerUrl?: string) => [
   columnHelper.accessor('slot', {
     header: () => <HeaderTooltip header="Slot" tooltip={headerTooltip.slot} />,
@@ -32,6 +79,18 @@ const getColumns = (blackExplorerUrl?: string) => [
           {slot.toLocaleString()}
         </Link>
       )
+    },
+  }),
+  columnHelper.accessor('date', { // Adding the 'date' column
+    header: () => <HeaderTooltip header="Date" tooltip={headerTooltip.date} />,
+    cell: (info) => {
+      const slot = info.row.original.slot;
+      const relativeTime = getRelativeTimeFromSlot(slot);
+      const absoluteTime = getAbsoluteTimeFromSlot(slot); // Function for absolute time
+
+      return (
+        <span title={absoluteTime}>{relativeTime}</span> // Display relative time with title as absolute time
+      );
     },
   }),
   columnHelper.accessor('proposer', {

--- a/src/components/tables/types.ts
+++ b/src/components/tables/types.ts
@@ -2,6 +2,7 @@ import type { Warnings } from './MyValidatorsTable/components/WarningIcon'
 
 export interface Block {
   slot: number
+  date: string
   proposer: Proposer
   rewardType: 'vanila' | 'mev' | 'unknownrewardtype' | ''
   reward: number

--- a/src/components/views/LatestBlocksSP.tsx
+++ b/src/components/views/LatestBlocksSP.tsx
@@ -26,6 +26,7 @@ export function LatestBlocksSP() {
       }) => ({
         blockType,
         slot,
+        date: "",
         proposer: {
           withdrawalAddress: withdrawalAddress as `0x${string}`,
           validatorKey: validatorKey as `0x${string}`,


### PR DESCRIPTION
Adds a new column on latest blocks table that shows how long ago did each block got proposed. If mouse is hovered, it shows the absolute date in local time of the block.

![Screenshot_20240102_113156](https://github.com/dappnode/mev-sp-fe/assets/36164126/1e7aafae-f2f0-47d9-9def-cf27b41c7f79)
