### PR TITLE
-Add overflow-hidden to banner in order to not expand page's width

### DIFF
--- a/src/components/common/Banner/index.tsx
+++ b/src/components/common/Banner/index.tsx
@@ -1,6 +1,6 @@
 export default function Banner() {
   return (
-    <div className="flex items-center border-b border-purple-500 bg-white py-2.5 sm:px-3.5 sm:before:flex-1">
+    <div className="flex items-center border-b border-purple-500 bg-white py-2.5 sm:px-3.5 sm:before:flex-1 overflow-hidden">
       <p className="rotating-text text-sm leading-6 text-black">
         <div className="flex space-x-2">
           <strong className="mx-2 font-semibold ">🎁 Special NY Gift 🎉</strong>


### PR DESCRIPTION
Adding overflow-hidden class to not let the screen width expand when banner rotation is rendered