### PR TITLE
Fix wrong singlevalidatorbyindex schema

### DIFF
--- a/src/client/api/queryFunctions.ts
+++ b/src/client/api/queryFunctions.ts
@@ -6,6 +6,7 @@ import {
   DonationSchema,
   StatusSchema,
   StatisticsSchema,
+  singleValidatorByIndexSchema,
   ValidatorSchema,
   onChainProofSchema,
   registeredRelaysSchema,
@@ -52,7 +53,7 @@ export const fetchValidatorsByDepositor = async (
 
 export const fetchValidatorByIndex = async (index: number) => {
   const response = await apiClient.get(endpoints.memoryValidator(index))
-  return ValidatorSchema.parse(convertKeysToCamelCase(response.data))
+  return singleValidatorByIndexSchema.parse(convertKeysToCamelCase(response.data))
 }
 
 export const fetchAllBlocks = async () => {

--- a/src/client/api/schemas.ts
+++ b/src/client/api/schemas.ts
@@ -37,6 +37,16 @@ export const ValidatorSchema = z.object({
   validatorKey: z.string(),
 })
 
+export const singleValidatorByIndexSchema = z.object({
+  status: z.string(),
+  accumulatedRewardsWei: z.number().or(z.null()),
+  pendingRewardsWei: z.number().or(z.null()),
+  collateralWei: z.number().or(z.null()),
+  withdrawalAddress: z.string(),
+  validatorIndex: z.number(),
+  validatorKey: z.string(),
+})
+
 export const StatusSchema = z.object({
   isConsensusInSync: z.boolean(),
   isExecutionInSync: z.boolean(),


### PR DESCRIPTION
Needed to use a different validator schema for endpoint /memory/validator/<valindex> because it returns `accumulatedRewardsWei`, `pendingRewardsWei`, and `collateralWei` as number instead of string

