### PR TITLE
Memo to ensure validatorsQuery data doesnt change

### DIFF
--- a/src/components/views/UserInfo.tsx
+++ b/src/components/views/UserInfo.tsx
@@ -10,6 +10,8 @@ import {
   fetchValidatorsByDepositor,
   validateServerStatus,
 } from '@/client/api/queryFunctions'
+import { useEffect, useMemo } from 'react'
+import { Warnings } from '../tables/MyValidatorsTable/components/WarningIcon'
 
 export function UserInfo() {
   const { isConnected, address } = useAccount()
@@ -49,36 +51,37 @@ export function UserInfo() {
     }
   }
 
-  let tableData: Validator[] = []
-  if (validatorsQuery.data) {
-    tableData = validatorsQuery.data.map(
-      ({
-        status,
-        validatorKey,
-        validatorIndex,
-        pendingRewardsWei,
-        accumulatedRewardsWei,
-      }) => ({
-        address: validatorKey as `0x${string}`,
-        pending: weiToEth(pendingRewardsWei || 0),
-        accumulated: weiToEth(accumulatedRewardsWei || 0),
-        subscribed: ['active', 'yellowcard', 'redcard'].includes(status),
-        validatorId: validatorIndex,
-        validatorKey: validatorKey as `0x${string}`,
-        warning: setWarning(status),
-        checkbox: false,
-      })
-    )
-  }
+  const memoizedTableData = useMemo(() => {
+    return validatorsQuery.data
+      ? validatorsQuery.data.map(
+          ({
+            status,
+            validatorKey,
+            validatorIndex,
+            pendingRewardsWei,
+            accumulatedRewardsWei,
+          }) => ({
+            address: validatorKey as `0x${string}`,
+            pending: weiToEth(pendingRewardsWei || 0),
+            accumulated: weiToEth(accumulatedRewardsWei || 0),
+            subscribed: ['active', 'yellowcard', 'redcard'].includes(status),
+            validatorId: validatorIndex,
+            validatorKey: validatorKey as `0x${string}`,
+            warning: setWarning(status) as Warnings, // Adjust the type here
+            checkbox: false,
+          })
+        )
+      : []
+  }, [validatorsQuery.data])
 
   return (
     <div className="mt-8 grid w-full grid-cols-1 gap-4 sm:grid-cols-3 md:gap-6 lg:grid-cols-4">
       <div className="order-1 col-span-4 sm:order-1 sm:col-span-2 lg:col-span-3">
         <MyValidatorsTable
-          data={tableData}
+          data={memoizedTableData}
           isConnected={isConnected}
           isLoading={validatorsQuery.isLoading}
-          serverError={validatorsQuery.isError || !serverStatus.data?.ready}
+          serverError={validatorsQuery.isError || onChainProofQuery.isError}
         />
       </div>
       <div className="col-span-4 sm:order-2 sm:col-span-1">

--- a/src/components/views/UserInfo.tsx
+++ b/src/components/views/UserInfo.tsx
@@ -1,17 +1,16 @@
 import { MyRewards } from '../cards/MyRewards'
 import { MyValidatorsTable } from '../tables/MyValidatorsTable'
+import { Warnings } from '../tables/MyValidatorsTable/components/WarningIcon'
+import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useAccount, useNetwork } from 'wagmi'
 import { weiToEth } from '@/utils/web3'
-import type { Validator } from '@/components/tables/types'
 import {
   fetchOnChainProof,
   fetchStatus,
   fetchValidatorsByDepositor,
   validateServerStatus,
 } from '@/client/api/queryFunctions'
-import { useEffect, useMemo } from 'react'
-import { Warnings } from '../tables/MyValidatorsTable/components/WarningIcon'
 
 export function UserInfo() {
   const { isConnected, address } = useAccount()
@@ -51,28 +50,30 @@ export function UserInfo() {
     }
   }
 
-  const memoizedTableData = useMemo(() => {
-    return validatorsQuery.data
-      ? validatorsQuery.data.map(
-          ({
-            status,
-            validatorKey,
-            validatorIndex,
-            pendingRewardsWei,
-            accumulatedRewardsWei,
-          }) => ({
-            address: validatorKey as `0x${string}`,
-            pending: weiToEth(pendingRewardsWei || 0),
-            accumulated: weiToEth(accumulatedRewardsWei || 0),
-            subscribed: ['active', 'yellowcard', 'redcard'].includes(status),
-            validatorId: validatorIndex,
-            validatorKey: validatorKey as `0x${string}`,
-            warning: setWarning(status) as Warnings, // Adjust the type here
-            checkbox: false,
-          })
-        )
-      : []
-  }, [validatorsQuery.data])
+  const memoizedTableData = useMemo(
+    () =>
+      validatorsQuery.data
+        ? validatorsQuery.data.map(
+            ({
+              status,
+              validatorKey,
+              validatorIndex,
+              pendingRewardsWei,
+              accumulatedRewardsWei,
+            }) => ({
+              address: validatorKey as `0x${string}`,
+              pending: weiToEth(pendingRewardsWei || 0),
+              accumulated: weiToEth(accumulatedRewardsWei || 0),
+              subscribed: ['active', 'yellowcard', 'redcard'].includes(status),
+              validatorId: validatorIndex,
+              validatorKey: validatorKey as `0x${string}`,
+              warning: setWarning(status) as Warnings, // Adjust the type here
+              checkbox: false,
+            })
+          )
+        : [],
+    [validatorsQuery.data]
+  )
 
   return (
     <div className="mt-8 grid w-full grid-cols-1 gap-4 sm:grid-cols-3 md:gap-6 lg:grid-cols-4">

--- a/src/components/views/UserInfo.tsx
+++ b/src/components/views/UserInfo.tsx
@@ -81,7 +81,7 @@ export function UserInfo() {
           data={memoizedTableData}
           isConnected={isConnected}
           isLoading={validatorsQuery.isLoading}
-          serverError={validatorsQuery.isError || onChainProofQuery.isError}
+          serverError={validatorsQuery.isError || !serverStatus.data?.ready}
         />
       </div>
       <div className="col-span-4 sm:order-2 sm:col-span-1">


### PR DESCRIPTION
By using useMemo to memoize tableData, we ensure that the array reference remains the same as long as its content doesn't change, preventing unnecessary re-renders.