### PR TITLE
Add sorting by eth reward slot desc latestblocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-select": "^1.2.2",
     "@radix-ui/react-toggle-group": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.0.7",
+    "@radix-ui/react-icons": "^1.3.0",
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-query-devtools": "^4.36.1",
     "@tanstack/react-table": "^8.10.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@radix-ui/react-dialog':
     specifier: ^1.0.5
     version: 1.0.5(@types/react-dom@18.0.11)(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+  '@radix-ui/react-icons':
+    specifier: ^1.3.0
+    version: 1.3.0(react@18.2.0)
   '@radix-ui/react-select':
     specifier: ^1.2.2
     version: 1.2.2(@types/react-dom@18.0.11)(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
@@ -3101,6 +3104,14 @@ packages:
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-icons@1.3.0(react@18.2.0):
+    resolution: {integrity: sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==}
+    peerDependencies:
+      react: ^16.x || ^17.x || ^18.x
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /@radix-ui/react-id@1.0.1(@types/react@18.0.28)(react@18.2.0):

--- a/src/components/tables/LatestBlocksTable/index.tsx
+++ b/src/components/tables/LatestBlocksTable/index.tsx
@@ -9,6 +9,8 @@ import {
   getCoreRowModel,
   getPaginationRowModel,
   useReactTable,
+  getSortedRowModel,
+  SortingState,
 } from '@tanstack/react-table';
 import { useSearchInput } from '@/hooks/useSearchInput';
 import { addEthSuffix, shortenEthAddress } from '@/utils/web3';
@@ -77,7 +79,7 @@ const getAbsoluteTimeFromSlot = (slot: number) => {
 
 const getColumns = (blackExplorerUrl?: string) => [
   columnHelper.accessor('slot', {
-    header: () => <HeaderTooltip header="Slot" tooltip={headerTooltip.slot} />,
+    header: ({ column }) => <HeaderTooltip column={column} header="Slot" tooltip={headerTooltip.slot} />,
     cell: (info) => {
       const slot = info.getValue();
       return (
@@ -90,6 +92,7 @@ const getColumns = (blackExplorerUrl?: string) => [
         </Link>
       );
     },
+    enableSorting: true,
   }),
   columnHelper.accessor('date', {
     // Adding the 'date' column
@@ -122,9 +125,7 @@ const getColumns = (blackExplorerUrl?: string) => [
     },
   }),
   columnHelper.accessor('rewardType', {
-    header: () => (
-      <HeaderTooltip header="Reward Type" tooltip={headerTooltip.rewardType} />
-    ),
+    header: () => (<HeaderTooltip header="Reward Type" tooltip={headerTooltip.rewardType} />),
     cell: (info) => {
       const rewardType = info.getValue();
       let modifiedRewardType: string = rewardType;
@@ -138,9 +139,7 @@ const getColumns = (blackExplorerUrl?: string) => [
   }),
 
   columnHelper.accessor('reward', {
-    header: () => (
-      <HeaderTooltip header="Reward" tooltip={headerTooltip.reward} />
-    ),
+    header: ({ column }) => (<HeaderTooltip column={column} header="Reward" tooltip={headerTooltip.reward} />),
     cell: (info) => addEthSuffix(toFixedNoTrailingZeros(info.getValue(), 4)),
   }),
   columnHelper.accessor('blockType', {
@@ -157,6 +156,7 @@ const getColumns = (blackExplorerUrl?: string) => [
           : 'Wrong Fee';
       return formattedBlockType;
     },
+    enableSorting: true,
   }),
 ];
 
@@ -174,6 +174,8 @@ export function LatestBlocksTable({
   const [filterValue, setFilterValue] = useState<string>(
     filterOptions[0].value
   );
+  const [sorting, setSorting] = useState<SortingState>([]);
+
   const { searchInput, setSearchInput, debouncedSearchInput } =
     useSearchInput();
 
@@ -200,8 +202,13 @@ export function LatestBlocksTable({
         pageSize: PAGE_SIZE,
       },
     },
+    state: {
+      sorting,
+    },
+    onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(), 
   });
 
   if (isLoading) return <Skeleton title="Latest Smooth Blocks" />;

--- a/src/components/tables/components/HeaderTooltip.tsx
+++ b/src/components/tables/components/HeaderTooltip.tsx
@@ -1,19 +1,55 @@
-import { Tooltip } from '@/components/common/Tooltip'
+import { Column } from '@tanstack/react-table'; 
+import {
+  CaretSortIcon,
+  CaretDownIcon,
+  CaretUpIcon
+} from '@radix-ui/react-icons'
+import { ReactNode } from 'react';
+import { Tooltip } from '@/components/common/Tooltip';
+import type { Block } from '../types';
 
 interface HeaderTooltipProps {
-  header: string
-  tooltip?: string
+  header: string;
+  tooltip?: string;
+  column?: Column<Block, number>
 }
 
-export function HeaderTooltip({ header, tooltip }: HeaderTooltipProps) {
-  if (!tooltip) {
-    return <span>{header}</span>
+export function HeaderTooltip({ header, tooltip, column }: HeaderTooltipProps) {
+  const toggleSort = (event: React.MouseEvent | React.KeyboardEvent) => {
+    // Check if getToggleSortingHandler exists and then call the returned function with the event
+    const toggleHandler = column?.getToggleSortingHandler();
+    if (toggleHandler) {
+      toggleHandler(event);
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    // Check for the Enter key
+    if (event.key === 'Enter') {
+      toggleSort(event);
+    }
+  };
+
+  let sortIndicator: ReactNode = null;
+  if (column?.getIsSorted()) {
+    sortIndicator = column.getIsSorted() === 'desc' ? <CaretDownIcon /> : <CaretUpIcon />;
+  } else if (column?.getCanSort()) {
+    sortIndicator = <CaretSortIcon />;
   }
 
   return (
-    <span className="flex items-center justify-center">
-      <span className="mr-2">{header}</span>
-      <Tooltip tooltip={tooltip} />
+    <span
+      className="flex items-center justify-center cursor-pointer"
+      role="button"
+      tabIndex={0} // Make the element focusable
+      onClick={toggleSort}
+      onKeyDown={handleKeyDown}
+    >
+      <span className="mr-2 flex items-center">
+        <span>{header}</span>
+        <span className="ml-1">{sortIndicator}</span>
+      </span>
+      {tooltip && <Tooltip tooltip={tooltip} />}
     </span>
-  )
+  );
 }


### PR DESCRIPTION
You can now sort by asc/desc order in Reward and Slot columns of Latest Blocks table
![Screenshot_20240303_194217](https://github.com/dappnode/mev-sp-fe/assets/36164126/f5c340be-6b85-48a9-8e3c-ecf57182e833)

