### PR TITLE
fix repeated faq in landing

### DIFF
--- a/src/components/home/FAQs.tsx
+++ b/src/components/home/FAQs.tsx
@@ -21,8 +21,8 @@ const faqs = [
     },
     {
         id: 4,
-        question: "Does Smooth take my Consensus Layer (CL) rewards?",
-        answer: "No, Smooth does not take your CL rewards. CL rewards are always sent directly to your withdrawal address. Smooth only takes the execution layer rewards, which are the fees or MEV of the blocks you propose. These are the rewards that are sent to the fee recipient."
+        question: "Is there a fee that Dappnode takes for participating in Smooth?",
+        answer: "7% of all the Rewards go to supporting the development of Dappnode and sustainability of Smooth."
     }
 ]
 export default function FAQs() {


### PR DESCRIPTION
repeated faq line landing page
![Screenshot_20240416_134033](https://github.com/dappnode/mev-sp-fe/assets/36164126/540adb6e-c23b-46f7-b37f-dd856394cb85)

replacing for 
```
question: "Is there a fee that Dappnode takes for participating in Smooth?",
answer: "7% of all the Rewards go to supporting the development of Dappnode and sustainability of Smooth."
```