### PR TITLE
Mobile view fixes

### DIFF
--- a/src/components/dialogs/MobileMenuDialog/index.tsx
+++ b/src/components/dialogs/MobileMenuDialog/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router'
 import Image from 'next/image'
 import Link from 'next/link'
 import clsx from 'clsx'
+import { useState, useEffect } from 'react'
 import { Button } from '@/components/common/Button'
 import { PAGES } from '@/utils/config'
 import { ToggleThemeBtn } from '@/components/common/ToggleThemeBtn'
@@ -13,8 +14,22 @@ import { ToggleThemeBtn } from '@/components/common/ToggleThemeBtn'
 export function MobileMenuDialog() {
   const router = useRouter()
 
+  const [isOpen, setIsOpen] = useState(false)
+
+  useEffect(() => {
+    const handleRouteChange = () => {
+      setIsOpen(false)
+    }
+
+    router.events.on('routeChangeComplete', handleRouteChange)
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange)
+    }
+  }, [router.events])
+
   return (
-    <Dialog.Root>
+    <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
       <Dialog.Trigger asChild>
         <Button buttonType="unstyled" className="ml-4" size="none">
           <RxHamburgerMenu className="h-6 w-6" />

--- a/src/components/home/FAQs.tsx
+++ b/src/components/home/FAQs.tsx
@@ -2,70 +2,84 @@ import { Disclosure, Transition } from '@headlessui/react'
 import { MinusSmallIcon, PlusSmallIcon } from '@heroicons/react/24/outline'
 
 const faqs = [
-    {
-        id: 1,
-        question: "What do I need to claim my rewards?",
-        answer:
-            "Once your pending rewards are transformed into accumulated rewards after your block proposal, a claim transaction will be required from the withdrawal address to send the ETH rewards to your wallet.",
-    },
-    {
-        id: 2,
-        question: "Does Smooth take my Consensus Layer (CL) rewards?",
-        answer:
-            "No, Smooth does not take your CL rewards. CL rewards are always sent directly to your withdrawal address. Smooth only takes the execution layer rewards, which are the fees or MEV of the blocks you propose.",
-    },
-    {
-        id: 3,
-        question: "If I want to unsubscribe my validator from Smooth, when is the best time to do it?",
-        answer: "Unsubscribing a validator from Smooth causes it to lose all its pending rewards. Hence, the ideal moment to exit Smooth is just after your last successful block proposal is reflected in Smooth's Smart Contract. A successful block proposal transfers all pending rewards claimable, allowing you to claim them before unsubscribing. This approach minimizes the pending rewards lost when unsubscribing."
-    },
-    {
-        id: 4,
-        question: "Is there a fee that Dappnode takes for participating in Smooth?",
-        answer: "7% of all the Rewards go to supporting the development of Dappnode and sustainability of Smooth."
-    }
+  {
+    id: 1,
+    question: 'What do I need to claim my rewards?',
+    answer:
+      'Once your pending rewards are transformed into accumulated rewards after your block proposal, a claim transaction will be required from the withdrawal address to send the ETH rewards to your wallet.',
+  },
+  {
+    id: 2,
+    question: 'Does Smooth take my Consensus Layer (CL) rewards?',
+    answer:
+      'No, Smooth does not take your CL rewards. CL rewards are always sent directly to your withdrawal address. Smooth only takes the execution layer rewards, which are the fees or MEV of the blocks you propose.',
+  },
+  {
+    id: 3,
+    question:
+      'If I want to unsubscribe my validator from Smooth, when is the best time to do it?',
+    answer:
+      "Unsubscribing a validator from Smooth causes it to lose all its pending rewards. Hence, the ideal moment to exit Smooth is just after your last successful block proposal is reflected in Smooth's Smart Contract. A successful block proposal transfers all pending rewards claimable, allowing you to claim them before unsubscribing. This approach minimizes the pending rewards lost when unsubscribing.",
+  },
+  {
+    id: 4,
+    question: 'Is there a fee that Dappnode takes for participating in Smooth?',
+    answer:
+      '7% of all the Rewards go to supporting the development of Dappnode and sustainability of Smooth.',
+  },
 ]
 export default function FAQs() {
-    return (
-        <div className="mx-auto my-16 mt-32 max-w-7xl px-16 sm:py-32 lg:px-16 lg:py-10">
-            <div className="mx-auto divide-y divide-gray-900/10">
-                <h2 className="text-3xl font-bold leading-10 tracking-tight text-DAppDeep dark:text-DAppDarkText">Frequently asked questions</h2>
-                <dl className="mt-10 space-y-6 divide-y divide-gray-900/10">
-                    {faqs.map((faq) => (
-                        <Disclosure key={faq.question} as="div" className="pt-6">
-                            {({ open }) => (
-                                <>
-                                    <dt>
-                                        <Disclosure.Button className="flex w-full items-start justify-between text-left text-DAppDeep dark:text-DAppDarkText">
-                                            <span className="text-base font-semibold leading-7">{faq.question}</span>
-                                            <span className="ml-6 flex h-7 items-center">
-                                                {open ? (
-                                                    <MinusSmallIcon aria-hidden="true" className="h-6 w-6" />
-                                                ) : (
-                                                    <PlusSmallIcon aria-hidden="true" className="h-6 w-6" />
-                                                )}
-                                            </span>
-                                        </Disclosure.Button>
-                                    </dt>
-                                    <Transition
-                                        enter="transition ease-out duration-200"
-                                        enterFrom="opacity-0 -translate-y-1"
-                                        enterTo="opacity-100 translate-y-0"
-                                        leave="transition ease-in duration-150"
-                                        leaveFrom="opacity-100 translate-y-0"
-                                        leaveTo="opacity-0 -translate-y-1"
-                                        show={open}
-                                    >
-                                        <Disclosure.Panel as="dd" className="mt-2 pr-12">
-                                            <p className="text-base leading-7 text-DAppDeep dark:text-DAppGray">{faq.answer}</p>
-                                        </Disclosure.Panel>
-                                    </Transition>
-                                </>
-                            )}
-                        </Disclosure>
-                    ))}
-                </dl>
-            </div>
-        </div>
-    );
+  return (
+    <div className="mx-auto my-16 mt-32 max-w-7xl pl-5 pr-2 sm:py-32 md:px-16 lg:px-16 lg:py-10">
+      <div className="mx-auto divide-y divide-gray-900/10">
+        <h2 className="text-3xl font-bold leading-10 tracking-tight text-DAppDeep dark:text-DAppDarkText">
+          Frequently asked questions
+        </h2>
+        <dl className="mt-10 space-y-6 divide-y divide-gray-900/10">
+          {faqs.map((faq) => (
+            <Disclosure key={faq.question} as="div" className="pt-6">
+              {({ open }) => (
+                <>
+                  <dt>
+                    <Disclosure.Button className="flex w-full items-start justify-between text-left text-DAppDeep dark:text-DAppDarkText">
+                      <span className="text-base font-semibold leading-7">
+                        {faq.question}
+                      </span>
+                      <span className="ml-6 flex h-7 items-center">
+                        {open ? (
+                          <MinusSmallIcon
+                            aria-hidden="true"
+                            className="h-6 w-6"
+                          />
+                        ) : (
+                          <PlusSmallIcon
+                            aria-hidden="true"
+                            className="h-6 w-6"
+                          />
+                        )}
+                      </span>
+                    </Disclosure.Button>
+                  </dt>
+                  <Transition
+                    enter="transition ease-out duration-200"
+                    enterFrom="opacity-0 -translate-y-1"
+                    enterTo="opacity-100 translate-y-0"
+                    leave="transition ease-in duration-150"
+                    leaveFrom="opacity-100 translate-y-0"
+                    leaveTo="opacity-0 -translate-y-1"
+                    show={open}>
+                    <Disclosure.Panel as="dd" className="mt-2 pr-12">
+                      <p className="text-base leading-7 text-DAppDeep dark:text-DAppGray">
+                        {faq.answer}
+                      </p>
+                    </Disclosure.Panel>
+                  </Transition>
+                </>
+              )}
+            </Disclosure>
+          ))}
+        </dl>
+      </div>
+    </div>
+  )
 }

--- a/src/components/home/HowToSubscribe.tsx
+++ b/src/components/home/HowToSubscribe.tsx
@@ -43,14 +43,10 @@ export default function HowToSubscribe() {
             }
           }}>
           Change your validator&apos;s fee recipient to{' '}
-          <dl
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              cursor: 'pointer',
-              textDecoration: 'underline',
-            }}>
-            <dt>{SMOOTHING_POOL_ADDRESS}</dt>
+          <dl className="flex cursor-pointer justify-between underline">
+            <dt className="text-[0.6rem] md:text-sm lg:text-base">
+              {SMOOTHING_POOL_ADDRESS}
+            </dt>
             <dd>
               <svg
                 className="h-6 w-6"
@@ -129,7 +125,7 @@ export default function HowToSubscribe() {
 
   return (
     <div className="mx-auto mt-20 max-w-7xl px-16">
-      <div className="mx-auto max-w-2xl lg:text-center">
+      <div className="mx-auto max-w-2xl text-center">
         <h2 className="text-base font-semibold leading-7 text-purple-600">
           How to subscribe
         </h2>

--- a/src/components/layout/Footer/index.tsx
+++ b/src/components/layout/Footer/index.tsx
@@ -14,7 +14,7 @@ const socialIcons = {
 
 export function Footer() {
   return (
-    <footer className="flex h-36 flex-col items-center justify-center gap-y-4 border-t bg-white px-4 dark:border-DAppDarkSurface/400 dark:bg-DAppDarkSurface/200 sm:h-20 sm:flex-row sm:justify-between md:px-12">
+    <footer className="flex h-44 flex-col items-center justify-center gap-y-4 border-t bg-white px-4 dark:border-DAppDarkSurface/400 dark:bg-DAppDarkSurface/200 sm:h-20 sm:flex-row sm:justify-between md:h-36 md:px-12">
       <div className="flex flex-col items-center justify-between sm:flex-row">
         {/* Link with logo and text */}
         <div className="flex flex-col items-center gap-y-4 hover:underline sm:flex-row">


### PR DESCRIPTION
This PR includes the following changes in order to enhance the mobile view:
- Before `HowToSubscribe` section from landing was causing a bad layout. It was adding some unnecessary margin that was displacing the whole page.
![image](https://github.com/dappnode/mev-sp-fe/assets/52827122/38f31dc2-81af-4cec-a7ad-887f9bb4a5d3)
- Updating `FAQs` section from landing. It had too much padding in mobile view complicating its reading
- Now after navigating between routes in mobile view closes automatically the nav panel
- Higher footer