### PR TITLE
Blockscout integration

### DIFF
--- a/src/components/tables/LatestDonationsTable/index.tsx
+++ b/src/components/tables/LatestDonationsTable/index.tsx
@@ -12,7 +12,6 @@ import {
 } from '@tanstack/react-table'
 import { useSearchInput } from '@/hooks/useSearchInput'
 import { toFixedNoTrailingZeros } from '@/utils/decimals'
-import { getBeaconChainExplorer } from '@/utils/config'
 import { shortenEthAddress } from '@/utils/web3'
 import type { Donation } from '../types'
 

--- a/src/components/tables/LatestDonationsTable/index.tsx
+++ b/src/components/tables/LatestDonationsTable/index.tsx
@@ -19,7 +19,7 @@ import type { Donation } from '../types'
 
 const columnHelper = createColumnHelper<Donation>()
 
-const getDonationColumns = (blackExplorerUrl?: string) => [
+const getDonationColumns = (blockExplorerUrl?: string) => [
     columnHelper.accessor('blockNumber', {
     header: () => <HeaderTooltip header="Block Number" tooltip={headerTooltip.blockNumber} />,
     cell: (info) => {
@@ -27,7 +27,7 @@ const getDonationColumns = (blackExplorerUrl?: string) => [
       return (
         <Link
           className="font-medium underline"
-          href={getBeaconChainExplorer('block', blockNumber)}
+          href={`${blockExplorerUrl}/block/${blockNumber}`}
           rel="noopener noreferrer"
           target="_blank">
           {blockNumber.toLocaleString()}
@@ -42,7 +42,7 @@ const getDonationColumns = (blackExplorerUrl?: string) => [
           return (
             <Link
               className="font-medium underline"
-              href={getBeaconChainExplorer('tx', txHash)}
+              href={`${blockExplorerUrl}/tx/${txHash}`}
               rel="noopener noreferrer"
               target="_blank">
               {shortenEthAddress(txHash)}
@@ -58,7 +58,7 @@ const getDonationColumns = (blackExplorerUrl?: string) => [
           return (
             <Link
               className="font-medium underline"
-              href={`${blackExplorerUrl}/address/${sender}`}
+              href={`${blockExplorerUrl}/address/${sender}`}
               rel="noopener noreferrer"
               target="_blank">
               {shortenEthAddress(sender)}

--- a/src/components/views/LatestDonationsSP.tsx
+++ b/src/components/views/LatestDonationsSP.tsx
@@ -36,8 +36,8 @@ export function LatestDonationsSP() {
         isLoading={isLoading}
         blockExplorerUrl={
           SELECTED_CHAIN === 'mainnet'
-            ? 'https://beaconcha.in'
-            : 'https://prater.beaconcha.in'
+            ? 'https://eth.blockscout.com'
+            : 'https://eth-holesky.blockscout.com'
         }
       />
     </div>


### PR DESCRIPTION
"Latest Smooth Donations" links to block, tx and sender of each donations now point to 'https://eth.blockscout.com' or 'https://eth-holesky.blockscout.com', depending on the network.