### PR TITLE
filter out validators not active ongoing

### DIFF
--- a/src/client/api/queryFunctions.ts
+++ b/src/client/api/queryFunctions.ts
@@ -44,7 +44,14 @@ export const fetchValidatorsByDepositor = async (
   const response = await apiClient.get(
     endpoints.memoryValidators(address || '0x0')
   )
-  return ValidatorSchema.array().parse(convertKeysToCamelCase(response.data))
+  // Parse and convert the response data to camelCase
+  const validators = ValidatorSchema.array().parse(convertKeysToCamelCase(response.data))
+  // Filter validators to only include those with "active_ongoing" beaconStatus. We are not interested in them.
+  const filteredValidators = validators.filter(
+    (validator) => validator.beaconStatus === "active_ongoing"
+  );
+
+  return filteredValidators;
 }
 
 export const fetchValidatorByIndex = async (index: number) => {
@@ -100,7 +107,7 @@ export const fetchMultiValidatorRegisteredRelays = async (
   const delay = (ms: number | undefined) => new Promise(resolve => {
     setTimeout(resolve, ms);
   });
-    
+
   const responses = [];
 
   // eslint-disable-next-line no-restricted-syntax

--- a/src/client/api/schemas.ts
+++ b/src/client/api/schemas.ts
@@ -30,6 +30,7 @@ export const DonationSchema = z.object({
 
 export const ValidatorSchema = z.object({
   status: z.string(),
+  beaconStatus: z.string().or(z.null()),
   accumulatedRewardsWei: z.string().or(z.null()),
   pendingRewardsWei: z.string().or(z.null()),
   collateralWei: z.string().or(z.null()),


### PR DESCRIPTION
To be merged when https://github.com/dappnode/mev-sp-oracle/pull/229 is merged

before (not filtering 3 exited validators):
![Screenshot_20241014_204230](https://github.com/user-attachments/assets/f4d17797-8dfd-408a-a33c-3b2f2a93da81)

after:
![Screenshot_20241014_204244](https://github.com/user-attachments/assets/5d8a4937-098a-40ac-899d-df879f71d6cd)

Validator https://holesky.beaconcha.in/validator/1767689 with pubkey 0x8258...3567 is not in the table. Cant subscribe/unsubscribe it, avoiding bad/useless calls to oracle by user
![Screenshot_20241014_204414](https://github.com/user-attachments/assets/99ebdb0c-b248-40ef-a465-b43d49eb17b9)


