### PR TITLE
Sliding Banner fixes

### DIFF
--- a/src/components/banners/SlidingBanner.tsx
+++ b/src/components/banners/SlidingBanner.tsx
@@ -18,7 +18,7 @@ export default function SlidingBanner({
 
   useEffect(() => {
     const handleScroll = () => {
-      const navbarHeight = 120
+      const navbarHeight = 100
       setIsFixed(window.scrollY > navbarHeight)
     }
 
@@ -29,26 +29,31 @@ export default function SlidingBanner({
   }, [])
 
   return (
-    <a
-      href={link}
-      target="_blank"
-      rel="noopener noreferrer"
-      aria-label={`Link to ${title}`}
-      className={`group ${
-        isFixed ? 'fixed left-0 top-0 ' : 'relative '
-      } z-10 mb-8 flex h-14 w-screen flex-col  justify-center overflow-hidden
-      bg-purple-400 transition-colors ease-in-out
-      [mask-image:_linear-gradient(to_right,transparent_0,_black_200px,_black_calc(100%-200px),transparent_100%)]
-      hover:bg-purple-300/80 dark:bg-DAppPurple-900 hover:dark:bg-DAppPurple-900/80`}
-      style={{
-        marginLeft: 'calc(-51vw + 50%)',
-        marginRight: 'calc(-50vw + 50%)',
-      }}>
-      <div className="flex animate-slide">
-        <BannerContent title={title} text={text} btnText={btnText} />
-        <BannerContent title={title} text={text} btnText={btnText} />
-      </div>
-    </a>
+    // -marginTop to ignore body's tag padding
+    <div className="-mt-4 md:-mt-8 ">
+      <a
+        href={link}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`Link to ${title}`}
+        className={`group ${
+          isFixed ? 'fixed left-0 top-0 ' : 'relative '
+        } z-10 mb-8 flex h-14 w-screen flex-col  justify-center overflow-hidden 
+      bg-purple-400/90 transition-colors ease-in-out
+       [mask-image:_linear-gradient(to_right,transparent_0,_black_200px,_black_calc(100%-200px),transparent_100%)]
+      hover:bg-purple-400 dark:bg-DAppPurple-900/90 hover:dark:bg-DAppPurple-900`}
+        style={{
+          marginLeft: 'calc(-50vw + 49.7%)',
+          marginRight: 'calc(-50vw + 50%)',
+        }}>
+        <div className="flex animate-slide">
+          <BannerContent title={title} text={text} btnText={btnText} />
+          <BannerContent title={title} text={text} btnText={btnText} />
+        </div>
+      </a>
+      {/* render empty div with same size as the banner when this turns in to fixed position. This avoids viewport height to change and autoscroll */}
+      {isFixed && <div className="relative mb-8 h-20 " />}{' '}
+    </div>
   )
 }
 
@@ -71,8 +76,31 @@ function BannerContent({ title, btnText, text }: BannerContentProps) {
             width={50}
           />
           <span className="text-xl font-bold">{title}</span>
-          <p className="hidden text-lg lg:block">{'->'}</p>
-          <p className="hidden text-lg lg:block">{text}</p>
+          <Image
+            className="h-6 w-6 hidden lg:block"
+            alt="Dappnode logo"
+            src="/images/dappnode-logo.svg"
+            height={50}
+            width={50}
+          />
+        </div>
+        <p className="hidden text-lg lg:block">{text}</p>
+        <div className=" flex-row items-center gap-x-3 hidden lg:flex">
+          <Image
+            className="h-6 w-6"
+            alt="Dappnode logo"
+            src="/images/dappnode-logo.svg"
+            height={50}
+            width={50}
+          />
+          <span className="text-xl font-bold">{title}</span>
+          <Image
+            className="h-6 w-6"
+            alt="Dappnode logo"
+            src="/images/dappnode-logo.svg"
+            height={50}
+            width={50}
+          />
         </div>
         <div className="flex items-center justify-center rounded-lg bg-white p-2 text-DAppPurple-900 transition-colors duration-300 ease-in-out">
           <p className="font-bold">{btnText}</p>

--- a/src/components/banners/SlidingBanner.tsx
+++ b/src/components/banners/SlidingBanner.tsx
@@ -43,7 +43,7 @@ export default function SlidingBanner({
        [mask-image:_linear-gradient(to_right,transparent_0,_black_200px,_black_calc(100%-200px),transparent_100%)]
       hover:bg-purple-400 dark:bg-DAppPurple-900/90 hover:dark:bg-DAppPurple-900`}
         style={{
-          marginLeft: 'calc(-50vw + 49.7%)',
+          marginLeft: 'calc(-50.2vw + 50%)',
           marginRight: 'calc(-50vw + 50%)',
         }}>
         <div className="flex animate-slide">

--- a/src/components/banners/SlidingBanner.tsx
+++ b/src/components/banners/SlidingBanner.tsx
@@ -77,7 +77,7 @@ function BannerContent({ title, btnText, text }: BannerContentProps) {
           />
           <span className="text-xl font-bold">{title}</span>
           <Image
-            className="h-6 w-6 hidden lg:block"
+            className="hidden h-6 w-6 lg:block"
             alt="Dappnode logo"
             src="/images/dappnode-logo.svg"
             height={50}
@@ -85,7 +85,7 @@ function BannerContent({ title, btnText, text }: BannerContentProps) {
           />
         </div>
         <p className="hidden text-lg lg:block">{text}</p>
-        <div className=" flex-row items-center gap-x-3 hidden lg:flex">
+        <div className=" hidden flex-row items-center gap-x-3 lg:flex">
           <Image
             className="h-6 w-6"
             alt="Dappnode logo"

--- a/src/components/banners/SlidingBanner.tsx
+++ b/src/components/banners/SlidingBanner.tsx
@@ -38,7 +38,7 @@ export default function SlidingBanner({
         aria-label={`Link to ${title}`}
         className={`group ${
           isFixed ? 'fixed left-0 top-0 ' : 'relative '
-        } z-10 mb-8 flex h-14 w-screen flex-col  justify-center overflow-hidden 
+        } z-10 mb-8 flex h-14 w-screen flex-col justify-center overflow-hidden 
       bg-purple-400/90 transition-colors ease-in-out
        [mask-image:_linear-gradient(to_right,transparent_0,_black_200px,_black_calc(100%-200px),transparent_100%)]
       hover:bg-purple-400 dark:bg-DAppPurple-900/90 hover:dark:bg-DAppPurple-900`}
@@ -85,7 +85,7 @@ function BannerContent({ title, btnText, text }: BannerContentProps) {
           />
         </div>
         <p className="hidden text-lg lg:block">{text}</p>
-        <div className=" hidden flex-row items-center gap-x-3 lg:flex">
+        <div className="hidden flex-row items-center gap-x-3 lg:flex">
           <Image
             className="h-6 w-6"
             alt="Dappnode logo"

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -13,7 +13,7 @@ export default function Dashboard() {
         title="SmoothDAO Proposal "
         btnText="Click here"
         text="Discuss and decide the future of Smooth!"
-        link="https://discourse.dappnode.io/t/proposal-sip1-smooth-terms-of-use-policy/2388"
+        link="https://link.dappnode.io/7bhotl6"
       />
       <main>
         <Statistics />

--- a/src/pages/donate.tsx
+++ b/src/pages/donate.tsx
@@ -14,7 +14,7 @@ export default function Donate() {
         title="SmoothDAO Proposal "
         btnText="Click here"
         text="Discuss and decide the future of Smooth!"
-        link="https://discourse.dappnode.io/t/proposal-sip1-smooth-terms-of-use-policy/2388"
+        link="https://link.dappnode.io/7bhotl6"
       />
       <main className="mx-auto flex max-w-5xl items-center justify-between pt-6">
         <div className="relative mt-20 hidden h-[520px] w-[490px] lg:block">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ export default function Home() {
         title="SmoothDAO Proposal "
         btnText="Click here"
         text="Discuss and decide the future of Smooth!"
-        link="https://discourse.dappnode.io/t/proposal-sip1-smooth-terms-of-use-policy/2388"
+        link="https://link.dappnode.io/7bhotl6"
       />
       <Hero />
       <Stats />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,10 +5,17 @@ import FAQs from '@/components/home/FAQs'
 import JoinSmooth from '@/components/home/JoinSmooth'
 import Stats from '@/components/home/Stats'
 import WhySmooth from '@/components/home/WhySmooth'
+import SlidingBanner from '@/components/banners/SlidingBanner'
 
 export default function Home() {
   return (
     <>
+     <SlidingBanner
+        title="SmoothDAO Proposal "
+        btnText="Click here"
+        text="Discuss and decide the future of Smooth!"
+        link="https://discourse.dappnode.io/t/proposal-sip1-smooth-terms-of-use-policy/2388"
+      />
       <Hero />
       <Stats />
       <WhySmooth />

--- a/src/pages/stats.tsx
+++ b/src/pages/stats.tsx
@@ -54,7 +54,7 @@ export default function Stats() {
         title="SmoothDAO Proposal "
         btnText="Click here"
         text="Discuss and decide the future of Smooth!"
-        link="https://discourse.dappnode.io/t/proposal-sip1-smooth-terms-of-use-policy/2388"
+        link="https://link.dappnode.io/7bhotl6"
       />
       <div className={styles.row}>
         <div className={styles.column}>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -57,7 +57,7 @@ module.exports = {
         'screen-content': 'calc(100vh - 176px)',
       },
       animation: {
-        slide: 'slide 25s linear infinite',
+        slide: 'slide 45s linear infinite',
       },
       keyframes: {
         slide: {


### PR DESCRIPTION
- Adding `SlidingBanner` in home page
- Displaying `SlidingBanner`  at the top, without margin
- Fixing viewport height flickering when turning `SlidingBanner` to position `relative`/`fixed`
- Hover colors improvement
- Duplicating some content so it looks fuller
- Slower sliding