### PR TITLE
Sliding banner z-index fix

### DIFF
--- a/src/components/dialogs/BaseDialog/index.tsx
+++ b/src/components/dialogs/BaseDialog/index.tsx
@@ -38,7 +38,7 @@ export function BaseDialog({
       </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 h-full w-full bg-gray-600 opacity-30 " />
-        <Dialog.Content className="fixed left-[50%] top-[50%] min-h-min w-[500px] max-w-[95%] translate-x-[-50%] translate-y-[-50%] rounded-lg bg-white p-6 dark:bg-DAppDarkSurface-200 md:max-w-[85%]">
+        <Dialog.Content className="fixed left-[50%] top-[50%] z-10 min-h-min w-[500px] max-w-[95%] translate-x-[-50%] translate-y-[-50%] rounded-lg bg-white p-6 dark:bg-DAppDarkSurface-200 md:max-w-[85%]">
           <div className="flex w-full justify-between">
             <h4 className="text-lg font-normal text-DAppDeep dark:text-DAppDarkText ">
               {subtitle}

--- a/src/components/dialogs/MobileMenuDialog/index.tsx
+++ b/src/components/dialogs/MobileMenuDialog/index.tsx
@@ -40,7 +40,7 @@ export function MobileMenuDialog() {
         <AnimatePresence>
           <Dialog.Content>
             <motion.div
-              className="fixed right-0 top-0 h-screen w-[300px] max-w-[75%] border bg-white p-6 dark:border-0 dark:bg-DAppDarkSurface-200"
+              className="fixed right-0 top-0 z-10 h-screen w-[300px] max-w-[75%] border bg-white p-6 dark:border-0 dark:bg-DAppDarkSurface-200"
               animate={{
                 // opacity: 1,
                 x: 0,


### PR DESCRIPTION
z-index fix to avoid sliding banner to overlap actions dialogs (Unsub/Sub/Claim) and MobileMenu