### PR TITLE
Multi Unsub Button

### DIFF
--- a/src/components/dialogs/UnsubscribeToMevDialog/dialogs/MultiUnsubscribeDialog.tsx
+++ b/src/components/dialogs/UnsubscribeToMevDialog/dialogs/MultiUnsubscribeDialog.tsx
@@ -143,7 +143,7 @@ export function MultiUnsubscribeDialog({
                   <div className="flex flex-1  items-center">
                     <ul className="flex max-h-56 flex-col gap-2 overflow-y-scroll ">
                       {validatorIds.map((validator) => (
-                        <li>- {validator}</li>
+                        <li key={validator}>- {validator}</li>
                       ))}
                     </ul>
                   </div>

--- a/src/components/dialogs/UnsubscribeToMevDialog/dialogs/MultiUnsubscribeDialog.tsx
+++ b/src/components/dialogs/UnsubscribeToMevDialog/dialogs/MultiUnsubscribeDialog.tsx
@@ -1,0 +1,176 @@
+import { DialogProps } from '../types'
+import Link from 'next/link'
+import { type BaseError, useAccount } from 'wagmi'
+import { AiOutlineInfoCircle } from 'react-icons/ai'
+import { useEffect, useCallback } from 'react'
+import { StepProgressBar } from '@/components/common/StepProgressBar'
+import { Button } from '@/components/common/Button'
+import { FEEDBACK_SCRIPT_URL, SELECTED_CHAIN } from '@/utils/config'
+import { useHandleSubscriptionStatus } from '@/hooks/useHandleSubscriptionStatus'
+
+interface MultiUnsubscribeDialogProps extends DialogProps {
+  validatorIds: number[]
+  setShowCloseButton: (show: boolean) => void
+  selectedOptions: string[]
+  otherOption: string
+  otherOptionSelected: boolean
+  improvementsFeedback: string
+}
+
+export function MultiUnsubscribeDialog({
+  steps,
+  validatorIds,
+  setShowCloseButton,
+  handleChangeDialogState,
+  handleClose,
+  selectedOptions,
+  otherOptionSelected,
+  otherOption,
+  improvementsFeedback,
+}: MultiUnsubscribeDialogProps) {
+  const {
+    handleSubscription,
+    awaitingWalletConfirmations,
+    isConfirming,
+    isReceiptSuccess,
+    writeError,
+    receiptError,
+    hash,
+  } = useHandleSubscriptionStatus('unsub', validatorIds)
+
+  const { chain } = useAccount()
+  const postFeedbackData = useCallback(async () => {
+    const formData = new FormData()
+    formData.append('sheetName', 'unsub')
+    formData.append('network', SELECTED_CHAIN)
+    formData.append('validator-id', validatorIds.toString())
+    formData.append('why-options', selectedOptions.join('\n'))
+    formData.append('other-options', otherOptionSelected ? otherOption : '')
+    formData.append('improvements', improvementsFeedback)
+    formData.append('timestamp', new Date().toISOString())
+
+    if (FEEDBACK_SCRIPT_URL) {
+      await fetch(FEEDBACK_SCRIPT_URL, {
+        method: 'POST',
+        body: formData,
+      })
+    }
+  }, [
+    validatorIds,
+    selectedOptions,
+    otherOptionSelected,
+    otherOption,
+    improvementsFeedback,
+  ])
+
+  useEffect(() => setShowCloseButton(false), [setShowCloseButton])
+
+  useEffect(() => {
+    if (isReceiptSuccess) {
+      handleChangeDialogState('success')
+      postFeedbackData()
+    }
+  }, [isReceiptSuccess, handleChangeDialogState, postFeedbackData])
+
+  return (
+    <>
+      <div className="-mt-2 text-DAppDeep dark:text-DAppDarkText">
+        <h3 className="mb-6 text-left text-2xl font-bold">Unsubscribe</h3>
+        <StepProgressBar currentStep={2} steps={steps} />
+      </div>
+      <div className="flex h-full flex-1 flex-col items-center justify-center text-DAppDeep dark:text-DAppDarkText">
+        {awaitingWalletConfirmations ? (
+          <div className="flex w-fit animate-pulse flex-col items-center justify-center gap-3 rounded bg-violet-200 p-5 dark:bg-DAppDarkSurface-300 sm:flex-row">
+            <AiOutlineInfoCircle />
+            <p>Awaiting wallet confirmation.</p>
+          </div>
+        ) : isConfirming ? (
+          <div className="mx-auto my-2 flex w-fit flex-col items-center sm:flex-col">
+            <div className="flex w-fit animate-pulse flex-col items-center justify-center gap-3 rounded bg-violet-200 p-5 dark:bg-DAppDarkSurface-300 sm:flex-row">
+              <AiOutlineInfoCircle />
+              <p>Your unsubscriptions are being processed.</p>
+            </div>
+            <div className="mx-auto mt-2 max-w-fit">
+              <Link
+                className="text-violet-500 underline dark:text-violet-200"
+                href={`${chain?.blockExplorers?.default.url}/tx/${hash}`}
+                target="_blank">
+                Check the transaction on block explorer
+              </Link>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-1  flex-col justify-between">
+            {writeError && (
+              <div className="flex flex-1 flex-col items-center justify-center gap-5 text-center text-lg">
+                <p className="rounded bg-violet-200 p-5 dark:bg-DAppDarkSurface-300">
+                  An error occurred while sending the transaction. Please try
+                  again.
+                </p>
+
+                <div className="text-DAppRed">
+                  Error:{' '}
+                  {(writeError as BaseError).shortMessage || writeError.message}
+                </div>
+              </div>
+            )}
+
+            {receiptError && (
+              <div className="flex flex-1 flex-col items-center justify-center gap-5 text-center text-lg">
+                <p className="rounded bg-violet-200 p-5 dark:bg-DAppDarkSurface-300">
+                  An error occurred while confirming the transaction. Please try
+                  again.
+                </p>
+                {receiptError && (
+                  <div className="text-DAppRed">
+                    Error:{' '}
+                    {(receiptError as BaseError).shortMessage ||
+                      receiptError.message}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {!writeError &&
+              !receiptError &&
+              !awaitingWalletConfirmations &&
+              !isConfirming && (
+                <div className="my-10 flex flex-1 flex-col items-center gap-5">
+                  <p className="text-center text-lg">
+                    Are you sure you want to unsubscribe the following
+                    validators?
+                  </p>
+                  <div className="flex flex-1  items-center">
+                    <ul className="flex max-h-56 flex-col gap-2 overflow-y-scroll ">
+                      {validatorIds.map((validator) => (
+                        <li>- {validator}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              )}
+
+            {isReceiptSuccess && (
+              <p className="text-left text-lg">
+                Your unsubscriptions have been processed.
+              </p>
+            )}
+            <div className="flex flex-col">
+              <Button
+                onPress={handleSubscription}
+                isDisabled={awaitingWalletConfirmations || isConfirming}>
+                Unsubscribe
+              </Button>
+              <Button
+                buttonType="secondary"
+                className="mt-4"
+                onPress={handleClose}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/components/dialogs/UnsubscribeToMevDialog/dialogs/SuccessDialog.tsx
+++ b/src/components/dialogs/UnsubscribeToMevDialog/dialogs/SuccessDialog.tsx
@@ -4,14 +4,16 @@ import { Button } from '@/components/common/Button'
 import { CongratulationsIcon } from '@/components/icons'
 
 interface SuccessUnsubscribeDialog extends DialogProps {
-  validatorId: number
+  validatorIds: number | number[]
 }
 
 export function SuccessDialog({
   steps,
-  validatorId,
+  validatorIds,
   handleClose,
 }: SuccessUnsubscribeDialog) {
+  const isMultiAction = Array.isArray(validatorIds)
+
   return (
     <>
       <div className="-mt-2 text-DAppDeep dark:text-DAppDarkText">
@@ -21,13 +23,28 @@ export function SuccessDialog({
       <div className="mx-auto flex flex-col items-center gap-y-4 text-center text-lg text-DAppDeep dark:text-DAppDarkText sm:px-4">
         <CongratulationsIcon />
         <h4 className="font-bold">Success!</h4>
+        {isMultiAction ? (
+          <div className="my-10 flex flex-1 flex-col items-center gap-5">
+            <p>You have successfully unsubscribed the following validators:</p>
+            <div className="flex flex-1  items-center">
+              <ul className="flex max-h-56 flex-col gap-2 overflow-y-scroll ">
+                {validatorIds.map((validator) => (
+                  <li>- {validator}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        ) : (
+          <p>
+            You have successfully unsubscribed validator <b>{validatorIds}</b>{' '}
+            from Smooth.
+          </p>
+        )}
+
         <p>
-          You have successfully unsubscribed validator <b>{validatorId}</b> from
-          Smooth.
-        </p>
-        <p>
-          You can now change your fee recipient of you validator without any
-          penalties. We&#39;re sad to see you go!
+          You can now change your fee recipient of you validator
+          {isMultiAction && 's'} without any penalties. We&#39;re sad to see you
+          go!
         </p>
       </div>
       <Button buttonType="secondary" className="mt-4" onPress={handleClose}>

--- a/src/components/dialogs/UnsubscribeToMevDialog/dialogs/SuccessDialog.tsx
+++ b/src/components/dialogs/UnsubscribeToMevDialog/dialogs/SuccessDialog.tsx
@@ -29,7 +29,7 @@ export function SuccessDialog({
             <div className="flex flex-1  items-center">
               <ul className="flex max-h-56 flex-col gap-2 overflow-y-scroll ">
                 {validatorIds.map((validator) => (
-                  <li>- {validator}</li>
+                  <li key={validator}>- {validator}</li>
                 ))}
               </ul>
             </div>

--- a/src/components/dialogs/UnsubscribeToMevDialog/index.tsx
+++ b/src/components/dialogs/UnsubscribeToMevDialog/index.tsx
@@ -1,5 +1,6 @@
 import { InitialDialog, FeedbackDialog, SuccessDialog } from './dialogs'
 import { UnsubscribeDialog } from './dialogs/UnsubscribeDialog'
+import { MultiUnsubscribeDialog } from './dialogs/MultiUnsubscribeDialog'
 import { BaseDialog } from '../BaseDialog'
 import { useState } from 'react'
 import { useAccount } from 'wagmi'
@@ -7,7 +8,6 @@ import { AnimatePresence } from 'framer-motion'
 import { isWalletConnectedChainOk } from '@/utils/web3'
 import { useDialog } from '@/hooks/useDialog'
 import type { IDialogStates } from './types'
-import { MultiUnsubscribeDialog } from './dialogs/MultiUnsubscribeDialog'
 
 const steps = ['Confirmation', 'Feedback', 'Unsubscribe', 'Done']
 

--- a/src/components/dialogs/UnsubscribeToMevDialog/index.tsx
+++ b/src/components/dialogs/UnsubscribeToMevDialog/index.tsx
@@ -7,11 +7,16 @@ import { AnimatePresence } from 'framer-motion'
 import { isWalletConnectedChainOk } from '@/utils/web3'
 import { useDialog } from '@/hooks/useDialog'
 import type { IDialogStates } from './types'
+import { MultiUnsubscribeDialog } from './dialogs/MultiUnsubscribeDialog'
 
 const steps = ['Confirmation', 'Feedback', 'Unsubscribe', 'Done']
 
 interface UnsubscribeToMevDialogProps {
   validatorId: number
+}
+
+interface MultiUnsubscribeToMevDialogProps {
+  validatorIds: number[]
 }
 
 export function UnsubscribeToMevDialog({
@@ -88,7 +93,90 @@ export function UnsubscribeToMevDialog({
               handleChangeDialogState={setDialogState}
               handleClose={handleCloseDialog}
               steps={steps}
-              validatorId={validatorId}
+              validatorIds={validatorId}
+            />
+          )}
+        </div>
+      </AnimatePresence>
+    </BaseDialog>
+  )
+}
+
+
+export function MultiUnsubscribeToMevDialog({
+  validatorIds,
+}: MultiUnsubscribeToMevDialogProps) {
+  const { chain } = useAccount()
+  const [dialogState, setDialogState] = useState<IDialogStates>('initial')
+  const [showCloseButton, setShowCloseButton] = useState<boolean>(true)
+  const { open, handleOpenChange, handleClose } = useDialog()
+
+  // Feedback states. Have to be here since feedback data is sent when submitting the unsub, not when 'Feedback' step is completed
+  const [selectedOptions, setSelectedOptions] = useState<string[]>([])
+  const [otherOption, setOtherOption] = useState<string>('')
+  const [otherOptionSelected, setOtherOptionSelected] = useState<boolean>(false)
+  const [improvementsFeedback, setImprovementsFeedback] = useState<string>('')
+
+  const handleCloseDialog = () => {
+    setDialogState('initial')
+    handleClose()
+  }
+
+  const handleOpenChangeDialog = (newOpen: boolean) => {
+    handleOpenChange(newOpen)
+    if (!newOpen) setDialogState('initial')
+  }
+
+
+  return (
+    <BaseDialog
+      disabledTrigger={!isWalletConnectedChainOk(chain)}
+      handleOpenChange={handleOpenChangeDialog}
+      open={open}
+      showCloseButton={showCloseButton}
+      subtitle="Unsubscribe selected Validators"
+      triggerButtonProp="outline"
+      triggerText="Unsubscribe selected Validators">
+      <AnimatePresence>
+        <div className="flex h-full min-h-[600px] flex-col justify-between text-DAppDeep">
+          {dialogState === 'initial' ? (
+            <InitialDialog
+              handleChangeDialogState={setDialogState}
+              handleClose={handleCloseDialog}
+              steps={steps}
+            />
+          ) : dialogState === 'feedback' ? (
+            <FeedbackDialog
+              handleChangeDialogState={setDialogState}
+              handleClose={handleCloseDialog}
+              steps={steps}
+              selectedOptions={selectedOptions}
+              setSelectedOptions={setSelectedOptions}
+              otherOption={otherOption}
+              setOtherOption={setOtherOption}
+              otherOptionSelected={otherOptionSelected}
+              setOtherOptionSelected={setOtherOptionSelected}
+              improvementsFeedback={improvementsFeedback}
+              setImprovementsFeedback={setImprovementsFeedback}
+            />
+          ) : dialogState === 'unsubscribe' ? (
+            <MultiUnsubscribeDialog
+              handleChangeDialogState={setDialogState}
+              handleClose={handleCloseDialog}
+              setShowCloseButton={setShowCloseButton}
+              steps={steps}
+              validatorIds={validatorIds}
+              selectedOptions={selectedOptions}
+              otherOption={otherOption}
+              otherOptionSelected={otherOptionSelected}
+              improvementsFeedback={improvementsFeedback}
+            />
+          ) : (
+            <SuccessDialog
+              handleChangeDialogState={setDialogState}
+              handleClose={handleCloseDialog}
+              steps={steps}
+              validatorIds={validatorIds}
             />
           )}
         </div>

--- a/src/components/tables/MyValidatorsTable/index.tsx
+++ b/src/components/tables/MyValidatorsTable/index.tsx
@@ -19,8 +19,14 @@ import {
   useReactTable,
   getSortedRowModel,
 } from '@tanstack/react-table'
-import { SubscribeToMevDialog, MultiSubscribeToMevDialog } from '@/components/dialogs/SubscribeToMevDialog'
-import { UnsubscribeToMevDialog } from '@/components/dialogs/UnsubscribeToMevDialog'
+import {
+  SubscribeToMevDialog,
+  MultiSubscribeToMevDialog,
+} from '@/components/dialogs/SubscribeToMevDialog'
+import {
+  MultiUnsubscribeToMevDialog,
+  UnsubscribeToMevDialog,
+} from '@/components/dialogs/UnsubscribeToMevDialog'
 import { useSearchInput } from '@/hooks/useSearchInput'
 import { addEthSuffix, shortenEthAddress } from '@/utils/web3'
 import { toFixedNoTrailingZeros } from '@/utils/decimals'
@@ -29,8 +35,14 @@ import type { Validator } from '../types'
 
 const columnHelper = createColumnHelper<Validator>()
 
-const useTableColumns = (table: { getIsAllRowsSelected: () => boolean | undefined; getToggleAllRowsSelectedHandler: () => ChangeEventHandler<HTMLInputElement> | undefined }) =>
-  useMemo(() => [
+const useTableColumns = (table: {
+  getIsAllRowsSelected: () => boolean | undefined
+  getToggleAllRowsSelectedHandler: () =>
+    | ChangeEventHandler<HTMLInputElement>
+    | undefined
+}) =>
+  useMemo(
+    () => [
       columnHelper.accessor('checkbox', {
         header: () => (
           <input
@@ -128,8 +140,9 @@ const useTableColumns = (table: { getIsAllRowsSelected: () => boolean | undefine
           )
         },
       }),
-  ], [table])
-
+    ],
+    [table]
+  )
 
 interface MyValidatorsTableProps {
   data?: Validator[]
@@ -145,9 +158,11 @@ export function MyValidatorsTable({
   serverError,
 }: MyValidatorsTableProps) {
   const { searchInput, setSearchInput, debouncedSearchInput } = useSearchInput()
-  const [showMultiSubscribeDialog, setShowMultiSubscribeDialog] = useState(false);
-  const [selectedValidatorIds, setSelectedValidatorIds] = useState<number[]>([]);
-  const [selectedValidatorKeys, setSelectedValidatorKeys] = useState<`0x${string}`[]>([]);
+  const [showMultiActionsDialog, setShowMultiActionsDialog] = useState(false)
+  const [selectedValidatorIds, setSelectedValidatorIds] = useState<number[]>([])
+  const [selectedValidatorKeys, setSelectedValidatorKeys] = useState<
+    `0x${string}`[]
+  >([])
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [columns, setColumns] = useState<ColumnDef<Validator, any>[]>([])
@@ -194,24 +209,30 @@ export function MyValidatorsTable({
     getSortedRowModel: getSortedRowModel(),
   })
 
-  const generatedColumns = useTableColumns(table);
+  const generatedColumns = useTableColumns(table)
 
   useEffect(() => {
     // Update columns when generatedColumns changes
-    setColumns(generatedColumns);
-  }, [generatedColumns]);
+    setColumns(generatedColumns)
+  }, [generatedColumns])
 
   useEffect(() => {
-    const selectedRowsData = table.getSelectedRowModel().rows.map(row => row.original);
-    const validatorIds = selectedRowsData.map(validator => validator.validatorId);
-    const validatorKeys = selectedRowsData.map(validator => validator.validatorKey);
-    setSelectedValidatorKeys(validatorKeys);
-    setSelectedValidatorIds(validatorIds);
+    const selectedRowsData = table
+      .getSelectedRowModel()
+      .rows.map((row) => row.original)
+    const validatorIds = selectedRowsData.map(
+      (validator) => validator.validatorId
+    )
+    const validatorKeys = selectedRowsData.map(
+      (validator) => validator.validatorKey
+    )
+    setSelectedValidatorKeys(validatorKeys)
+    setSelectedValidatorIds(validatorIds)
 
     // Show the dialog only if two or more validators are selected
-    setShowMultiSubscribeDialog(validatorIds.length >= 2);
+    setShowMultiActionsDialog(validatorIds.length >= 2)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [table, table.getSelectedRowModel()]);
+  }, [table, table.getSelectedRowModel()])
 
   if (!isConnected) {
     return <NotConnectedWarning title="My Validators" />
@@ -227,11 +248,14 @@ export function MyValidatorsTable({
 
   return (
     <>
-      {showMultiSubscribeDialog && (
-        <MultiSubscribeToMevDialog
-          validatorIds={selectedValidatorIds}
-          validatorKeys={selectedValidatorKeys}
-        />
+      {showMultiActionsDialog && (
+        <div className="flex w-full flex-col gap-2">
+          <MultiSubscribeToMevDialog
+            validatorIds={selectedValidatorIds}
+            validatorKeys={selectedValidatorKeys}
+          />
+          <MultiUnsubscribeToMevDialog validatorIds={selectedValidatorIds} />
+        </div>
       )}
       <TableLayout
         showEmptyMessage

--- a/src/contract/abi.json
+++ b/src/contract/abi.json
@@ -30,6 +30,19 @@
     "inputs": [
       {
         "indexed": false,
+        "internalType": "uint64",
+        "name": "validatorID",
+        "type": "uint64"
+      }
+    ],
+    "name": "BanValidator",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
         "internalType": "address",
         "name": "withdrawalAddress",
         "type": "address"
@@ -233,6 +246,19 @@
     "inputs": [
       {
         "indexed": false,
+        "internalType": "uint64",
+        "name": "validatorID",
+        "type": "uint64"
+      }
+    ],
+    "name": "UnbanValidator",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
         "internalType": "address",
         "name": "sender",
         "type": "address"
@@ -345,6 +371,19 @@
     "name": "addressToVotedReportHash",
     "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64[]",
+        "name": "validatorIDArray",
+        "type": "uint64[]"
+      }
+    ],
+    "name": "banValidators",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -646,9 +685,35 @@
   },
   {
     "inputs": [
+      {
+        "internalType": "uint64[]",
+        "name": "validatorIDArray",
+        "type": "uint64[]"
+      }
+    ],
+    "name": "unbanValidators",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
       { "internalType": "uint64", "name": "validatorID", "type": "uint64" }
     ],
     "name": "unsubscribeValidator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64[]",
+        "name": "validatorIDArray",
+        "type": "uint64[]"
+      }
+    ],
+    "name": "unsubscribeValidators",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/src/hooks/useHandleSubscriptionStatus.ts
+++ b/src/hooks/useHandleSubscriptionStatus.ts
@@ -19,10 +19,6 @@ export function useHandleSubscriptionStatus(
   methodName: 'sub' | 'unsub',
   validatorIds: number | number[]
 ) {
-  // Throwing error if trying to multiunsub
-  if (methodName === 'unsub' && Array.isArray(validatorIds))
-    throw new Error('Mutiple unsubscription not unsported!')
-
   const isMultiAction = Array.isArray(validatorIds)
   const { address } = useAccount()
   const queryClient = useQueryClient()
@@ -66,7 +62,6 @@ export function useHandleSubscriptionStatus(
   const handleSubscription = useCallback(async () => {
     const abi = [...contractInterface] as const
 
-
     try {
       await write({
         abi,
@@ -76,7 +71,11 @@ export function useHandleSubscriptionStatus(
             ? isMultiAction
               ? 'subscribeValidators'
               : 'subscribeValidator'
-            : 'unsubscribeValidator',
+            : methodName === 'unsub'
+            ? isMultiAction
+              ? 'unsubscribeValidators'
+              : 'unsubscribeValidator'
+            : '',
         value:
           methodName === 'sub'
             ? utils.parseEther(totalDepositInString).toBigInt()


### PR DESCRIPTION
Since Smooth's SC update, it is now possible to unsubscribe multiple validators simultaneously.

This PR includes:
- The logic to enable this action. 
- "Multi-Unsubscribe" button is displayed below the "Multi-Subscribe" button when multiple validators are selected in the "My Validators" table.
- Corresponding "Multi-Unsubscribe" dialog.